### PR TITLE
Restore no save

### DIFF
--- a/SignallingWebServer/.gitignore
+++ b/SignallingWebServer/.gitignore
@@ -1,4 +1,5 @@
 build/
 node_modules/
 www/
+config.json
 ssl/

--- a/SignallingWebServer/.gitignore
+++ b/SignallingWebServer/.gitignore
@@ -1,5 +1,4 @@
 build/
 node_modules/
 www/
-config.json
 ssl/

--- a/SignallingWebServer/README.md
+++ b/SignallingWebServer/README.md
@@ -74,9 +74,8 @@ Options:
   --no_config                       Skips the reading of the config file. Only CLI options will be used. (default:
                                     false)
   --config_file <path>              Sets the path of the config file. (default: "config.json")
-  --no_save                         On startup the given configuration is resaved out to config.json. This switch will
-                                    prevent this behaviour allowing the config.json file to remain untouched while
-                                    running with new configurations. (default: false)
+  --save                            After arguments are parsed the config.json is saved with whatever arguments were
+                                    specified at launch. (default: false)
   -h, --help                        Display this help text.
 ```
 These CLI options can also be described in a `config.json` (default config file overridable with --config_file) by specifying the command option name and value in a simple JSON object. eg.

--- a/SignallingWebServer/config.json
+++ b/SignallingWebServer/config.json
@@ -1,0 +1,21 @@
+{
+	"log_folder": "logs",
+	"log_level_console": "info",
+	"log_level_file": "info",
+	"streamer_port": "8888",
+	"player_port": "80",
+	"sfu_port": "8889",
+	"serve": true,
+	"http_root": "D:\\PixelStreamingInfrastructure\\SignallingWebServer\\www",
+	"homepage": "player.html",
+	"https": false,
+	"https_port": 443,
+	"ssl_key_path": "certificates/client-key.pem",
+	"ssl_cert_path": "certificates/client-cert.pem",
+	"https_redirect": true,
+	"rest_api": false,
+	"peer_options": "",
+	"log_config": true,
+	"stdin": false,
+	"console_messages": "verbose"
+}

--- a/SignallingWebServer/from_cirrus.md
+++ b/SignallingWebServer/from_cirrus.md
@@ -3,10 +3,11 @@
 This is just a small brief to describe the differences between the now deprecated `cirrus` signalling server and the new `wilbur` signalling server.
 
 - Configuration is handled by CLI options or the same options in a `config.json`
-- By default web serving is disabled but can be enabled by supplying --serve
-- Convenience scripts in `platform_scripts' will append --serve and try to preproduce old cirrus behaviour.
-- Frontend will be placed in `www` instead of `Public` when using convenience scripts.
+- By default web serving is disabled but can be enabled by supplying `--serve`
+- Convenience scripts in `platform_scripts` will append `--serve` and try to reproduce the old `cirrus.js` behaviour.
+- The frontend will be placed in `www` instead of `Public` when using convenience scripts.
 - Messages are now described by protobufs in the [Common](../Common/protobuf/signalling_messages.proto) library.
 - The server is built on top of the [Common](../Common) library which is provided as a tool for developers to build their own applications.
-- Logs from wilbur are now structured JSON so they can be easily ingested into external tools.
-- Messages sent and received are no longer echoed to the terminal by default. The --console_messages argument can control this behaviour.
+- Logs from `wilbur` are now structured JSON so they can be easily ingested into external tools.
+- Messages sent and received are no longer echoed to the terminal by default. The `--console_messages` argument can control this behaviour.
+- The `config.json` file will not be created or recreated (if deleted), if you want the config.json to be generated based on current arguments use `--save`.

--- a/SignallingWebServer/src/index.ts
+++ b/SignallingWebServer/src/index.ts
@@ -86,7 +86,7 @@ program
         .default(config_file.peer_options || ""))
     .option('--log_config', 'Will print the program configuration on startup.', config_file.log_config || false)
     .option('--stdin', 'Allows stdin input while running.', config_file.stdin || false)
-    .option('--no_save', 'On startup the given configuration is resaved out to config.json. This switch will prevent this behaviour allowing the config.json file to remain untouched while running with new configurations.', config_file.no_save || false)
+    .option('--save', 'After arguments are parsed the config.json is saved with whatever arguments were specified at launch.', config_file.save || false)
     .helpOption('-h, --help', 'Display this help text.')
     .allowUnknownOption() // ignore unknown options which will allow versions to be swapped out into existing scripts with maybe older/newer options
     .parse();
@@ -96,13 +96,13 @@ const cli_options: IProgramOptions = program.opts();
 const options: IProgramOptions = { ...cli_options };
 
 // save out new configuration (unless disabled)
-if (!options.no_save) {
+if (options.save) {
 
     // dont save certain options
     const save_options = { ...options };
     delete save_options.no_config;
     delete save_options.config_file;
-    delete save_options.no_save;
+    delete save_options.save;
 
     // save out the config file with the current settings
     fs.writeFile(configArgsParser.config_file, beautify(save_options), (error: any) => {


### PR DESCRIPTION
### Description

The changes in this pull request include updating the CLI options for the Signalling Web Server, adding a new `config.json` file for configuration settings, and updating some documentation to reflect these changes. Here is a summary of the modifications:

- Added a new `config.json` file to specify configuration settings for the Signalling Web Server.
- Updated CLI options to allow saving configurations to `config.json` with the `--save` option.
- Updated documentation to reflect changes in handling configurations and serving content.

These changes aim to enhance the configuration flexibility and improve the experience of setting up and running the Signalling Web Server.

If you want the config.json to be generated based on the current arguments, use the `--save` option.

The changes in the files are as follows:

- Added config.json file with default configuration settings.
- Updated index.ts to handle saving configurations with the `--save` option.
- Updated documentation to reflect the changes in configuration handling and serving content locations.