### PR TITLE
Svc

### DIFF
--- a/SFU/config.js
+++ b/SFU/config.js
@@ -18,7 +18,7 @@ const config = {
   SFUId: "SFU",
 
   // The ID of the streamer to subscribe to. If you leave this blank it will subscribe to the first streamer it sees.
-  subscribeStreamerId: "DefaultStreamer",
+  subscribeStreamerId: "",
 
   // Delay between list requests when looking for a specifc streamer.
   retrySubscribeDelaySecs: 10,
@@ -35,12 +35,12 @@ const config = {
         "rtp",
         "srtp",
         "rtcp",
-        "sctp"
+        "sctp",
         // 'rtx',
         // 'bwe',
         // 'score',
-        // 'simulcast',
-        // 'svc'
+        'simulcast',
+        'svc'
       ],
     },
     router: {
@@ -54,12 +54,7 @@ const config = {
         {
           kind: 'video',
           mimeType: 'video/VP8',
-          clockRate: 90000,
-          parameters: {
-            "packetization-mode": 1,
-            "profile-level-id": "42e01f",
-            "level-asymmetry-allowed": 1
-          }
+          clockRate: 90000
         },
         {
           kind: "video",
@@ -71,7 +66,11 @@ const config = {
             "level-asymmetry-allowed": 1
           },
         },
-        
+        {
+          kind: "video",
+          mimeType: "video/VP9",
+          clockRate: 90000
+        }
       ],
     },
 

--- a/SFU/mediasoup-sdp-bridge/lib/SdpUtils.js
+++ b/SFU/mediasoup-sdp-bridge/lib/SdpUtils.js
@@ -75,6 +75,10 @@ function sdpToSendRtpParameters(sdpObject, sdpMediaObj, localCaps, kind) {
         //     kind,
         // });
         sendParams.encodings = MsRtpUtils.getRtpEncodings({ offerMediaObject: sdpMediaObj });
+        if(kind === "video")
+        {
+            sendParams.encodings[0].scalabilityMode = "L3T3";
+        }
     }
     sendParams.rtcp = {
         cname: MsSdpUtils.getCname({ offerMediaObject: sdpMediaObj }),

--- a/SFU/sfu_server.js
+++ b/SFU/sfu_server.js
@@ -259,15 +259,22 @@ function disconnectAllPeers() {
 
 function onLayerPreference(msg) {
   const peer = peers.get(`${msg.playerId}`);
-  if (peer != null) {
-    for (consumer of peer.consumers) {
-      consumer.setPreferredLayers({ spatialLayer: msg.spatialLayer, temporalLayer: msg.temporalLayer });
+  for(let peer of [...peers.values()]) {
+    if (peer != null) {
+      console.log(msg)
+      for (consumer of peer.consumers) {
+        if (consumer.kind === "video")
+          {
+            console.log(`Changing { spatialLayer: ${consumer.currentLayers.spatialLayer}, temporalLayer: ${consumer.currentLayers.temporalLayer}} to { spatialLayer: ${msg.spatialLayer}, temporalLayer: ${msg.temporalLayer}}`);
+            consumer.setPreferredLayers({ spatialLayer: msg.spatialLayer, temporalLayer: msg.temporalLayer });
+          }
+      }
     }
   }
 }
 
 async function onSignallingMessage(message) {
-  //console.log(`Got MSG: ${message}`);
+  // console.log(`Got MSG: ${message}`);
   const msg = JSON.parse(message);
 
   if (msg.type == 'offer') {

--- a/SignallingWebServer/platform_scripts/cmd/common.bat
+++ b/SignallingWebServer/platform_scripts/cmd/common.bat
@@ -141,7 +141,7 @@ IF "%FRONTEND_DIR%"=="" (
 )
 
 rem try to make it an absolute path
-call :NormalizePath "%FRONTEND_DIR%"
+call :NormalizePath %FRONTEND_DIR%
 set FRONTEND_DIR=%RETVAL%
 
 rem Set this for webpack


### PR DESCRIPTION
### Description

- Removed the default value for `subscribeStreamerId` in the SFU configuration.
- Added support for "simulcast" and "svc" in the supported codecs list in the SFU configuration.
- Updated the supported video codecs in the SFU configuration to only include the `clockRate` property for VP8, added support for VP9 codec with clock rate 90000, and configured its scalability mode to "L3T3".
- Updated the handling of layer preferences to ensure that only video consumers are considered for setting preferred spatial and temporal layers.
- Updated the normalization of the FRONTEND_DIR path.

These changes reflect adjustments in the SFU configuration, codec support, layer preference handling, and path normalization for the FRONTEND_DIR.